### PR TITLE
WABA client new version: 16.0

### DIFF
--- a/__tests__/client.test.ts
+++ b/__tests__/client.test.ts
@@ -137,7 +137,10 @@ describe("WABA Cloud API endpoints", () => {
 			} catch (err: any) {
 				//The message id passed is not real.
 				//So to test that the endpoints is working we just compare with the err message
-				expect(err?.message).toBe("ParameterInvalid");
+				expect(err).toMatchObject<Partial<WABAErrorAPI>>({
+					code: 100,
+					message: ERROR_CODES[100],
+				});
 			}
 		});
 	});
@@ -195,8 +198,8 @@ describe("WABA Cloud API endpoints", () => {
 			//We cant verify with the real code
 			//So we just make sure that the API call was made
 			expect(err).toMatchObject<Partial<WABAErrorAPI>>({
-				message: ERROR_CODES[100],
-				code: 100,
+				message: ERROR_CODES[136025],
+				code: 136025,
 			});
 		}
 	});

--- a/src/WABA_client.ts
+++ b/src/WABA_client.ts
@@ -31,18 +31,16 @@ interface WABAClientArgs {
 }
 
 export class WABAClient {
-	private apiToken: string;
 	restClient: ReturnType<typeof createRestClient>;
 	phoneId: string;
 	accountId: string;
 
 	constructor({ apiToken, phoneId, accountId }: WABAClientArgs) {
-		this.apiToken = apiToken;
 		this.phoneId = phoneId;
 		this.accountId = accountId;
 		this.restClient = createRestClient({
 			apiToken,
-			baseURL: "https://graph.facebook.com/v15.0",
+			baseURL: "https://graph.facebook.com/v16.0",
 			errorHandler: (error) => WABAErrorHandler(error?.response?.data || error),
 		});
 	}

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -9,7 +9,7 @@ export const ERROR_CODES = {
 	3: "API Method",
 	4: "API Too Many Calls",
 	10: "API Permission Denied",
-	100: "ParameterInvalid",
+	100: "Invalid parameter",
 	190: "Access token has expired",
 	200: "API Permission",
 	299: "API Permission",
@@ -48,6 +48,7 @@ export const ERROR_CODES = {
 	133007: "Account Blocked",
 	133008: "Too Many PIN Guesses",
 	133009: "PIN Guessed Too Fast",
+	136025: "Verify code error",
 } as const;
 
 export type WABAErrorCodes = keyof typeof ERROR_CODES;

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -34,7 +34,15 @@ export type MessageType =
 	| "sticker"
 	| "template"
 	| "text"
-	| "video";
+	| "video"
+	| "reaction";
+
+export type MessageContext = {
+	/**
+	 * The message id you receive on the webhooks
+	 */
+	message_id: string;
+};
 
 export type Message = {
 	/**
@@ -43,6 +51,10 @@ export type Message = {
 	type?: MessageType;
 	messaging_product: LiteralUnion<"whatsapp">;
 	recipient_type?: LiteralUnion<"individual">;
+	/**
+	 * Use it if you want to use the reply-to feature when answering a message
+	 */
+	context?: MessageContext;
 	/**
 	 * WhatsApp ID or phone number for the person you want to send a message to.
 	 * See https://developers.facebook.com/docs/whatsapp/cloud-api/reference/phone-numbers#formatting for more information.
@@ -88,26 +100,41 @@ export type Message = {
 	 * Required when type=video.
 	 */
 	video?: MediaObject;
+	/**
+	 * Required when type=reaction.
+	 */
+	reaction?: ReactionMessage;
 };
 
 export type MediaObject = {
 	/**
 	 * Required when type is audio, document, or image and you are not using a link.
+	 *
+	 * You get the media object ID after uploading a media to whatsapp server. For further information refer here https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media#get-media-id
 	 */
 	id?: string;
 	/**
-	 * Required when type is audio, document, image, video, and sticker and you are not using an uploaded media ID.
+	 * Required when type is audio, document, image, sticker, or video and you are not using an uploaded media ID (i.e. you are hosting the media asset on your server).
+	 *
 	 * The protocol and URL of the media to be sent. Use only with HTTP/HTTPS URLs.
 	 */
 	link?: string;
 	/**
-	 * Describes the specified document or image media.
+	 * Describes the specified image, document, or video media.
+	 *
+	 * Do not use with audio or sticker media.
 	 */
 	caption?: string;
 	/**
 	 * Describes the filename for the specific document. Use only with document media.
+	 *
+	 * The extension of the filename will specify what format the document is displayed as in WhatsApp.
 	 */
 	filename?: string;
+	/**
+	 * This path is optionally used with a link when the HTTP/HTTPS link is not directly accessible and requires additional configurations like a bearer token.
+	 */
+	provider?: string;
 };
 
 export type ContactMessageAddress = {
@@ -317,13 +344,46 @@ export type TemplateMessage = {
 
 export type TextMessage = {
 	/**
-	 * 
-	 * The text of the text message which can contain URLs which begin with http:// or https:// and formatting. See available formatting options here.
- 	   
-		If you include URLs in your text and want to include a preview box in text messages (preview_url: true), make sure the URL starts with http:// or https:// —https:// URLs are preferred. You must include a hostname, since IP addresses will not be matched.
-
-		Maximum length: 4096 characters
+	 *
+	 * The text of the text message which can contain URLs which begin with
+	 * http:// or https:// and formatting. See available formatting options here
+	 * https://developers.facebook.com/docs/whatsapp/on-premises/reference/messages#formatting.
+	 *
+	 * If you include URLs in your text and want to include a preview box in text messages (preview_url: true), make sure the URL starts with http:// or https:// —https:// URLs are preferred. You must include a hostname, since IP addresses will not be matched.
+	 *
+	 * Maximum length: 4096 characters
 	 */
 	body: string;
+	/**
+	 * By default, WhatsApp recognizes URLs and makes them clickable,
+	 * but you can also include a preview box with more information about the link. Set this field to true if you want to include a URL preview box.
+	 *
+	 * The majority of the time, the receiver will see a URL they can click on when you send an URL, set preview_url to true, and provide a body object with a http or https link.
+	 *
+	 * Default: false.
+	 */
 	preview_url?: boolean;
+};
+
+export type ReactionMessage = {
+	/**
+	 * The WhatsApp Message ID (wamid) of the message on which the reaction should appear. The reaction will not be sent if:
+	 *
+	 *  - The message is older than 30 days
+	 *  - The message is a reaction message
+	 *  - The message has been deleted
+	 *
+	 * If the ID is of a message that has been deleted, the message will not be deliver
+	 */
+	message_id: string;
+	/**
+	 * Emoji to appear on the message.
+	 *
+	 * - All emojis supported by Android and iOS devices are supported.
+	 * - Rendered-emojis are supported.
+	 * - If using emoji unicode values, values must be Java- or JavaScript-escape encoded. to see emoji
+	 * - Only one emoji can be sent in a reaction message
+	 * - Use an empty string to remove a previously sent emoji.
+	 */
+	emoji: string;
 };

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -7,7 +7,8 @@
  * //And I still have autocompletion!
  * if (foo === "other_value") return;
  */
-export type LiteralUnion<T extends U, U = string> = T | (U & {}); // eslint-disable-line @typescript-eslint/ban-types
+export type LiteralUnion<T extends string> = T | (string & {}); // eslint-disable-line @typescript-eslint/ban-types
+
 /**
  * Adds number autocompletion as if it was a union, but allows other number values
  *
@@ -17,7 +18,7 @@ export type LiteralUnion<T extends U, U = string> = T | (U & {}); // eslint-disa
  * //And I still have autocompletion!
  * if (foo === 1) return;
  */
-export type LiteralNumberUnion<T extends U, U = number> = T | (U & {}); // eslint-disable-line @typescript-eslint/ban-types
+export type LiteralNumberUnion<T extends number> = T | (number & {}); // eslint-disable-line @typescript-eslint/ban-types
 
 /**
  * Takes a type and maps all its values to never

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -2,9 +2,15 @@ import { DefaultWABAErrorAPI } from "./../types";
 import { ERROR_CODES } from "../types";
 
 export const WABAErrorHandler = (error: DefaultWABAErrorAPI) => {
-	const err = error?.error || {};
-	err.message = ERROR_CODES[err.code];
+	const err = error?.error;
+	/**
+	 * If the err does not match the WABA schema return whatever error we got
+	 * All err responses from whatsapp should follow the DefaultWABAErrorAPI schema
+	 */
+	if (!err) return Promise.reject(error);
+	err.message = ERROR_CODES[err.code] || err.message;
 	if (!err.error_subcode) err.error_subcode = NaN;
 	if (!err.error_data) err.error_data = { details: "", messaging_product: "whatsapp" };
-	return Promise.reject(err.message ? err : error);
+
+	return Promise.reject(err);
 };


### PR DESCRIPTION
This merge updates the WABAClient to point to the latest version of the API. Also, its respective tests have been modified to match this new version.

This new version allows a new message type: Reaction and also adds support for the reply-to feature to answer a specific message.

This merge also includes minor fixes. More specifically, the autocompletion of the literal unions which was not working due to a new version of typescript, and the waba client error handler which sometimes didn't return the error object as intended.
