### PR TITLE
Namespace prop on TemplateMessage

### DIFF
--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -431,6 +431,7 @@ export type TemplateMessageLanguage = {
 };
 
 export type TemplateMessage = {
+	namespace: string;
 	name: string;
 	language: TemplateMessageLanguage;
 	components: TemplateMessageComponent[];


### PR DESCRIPTION
Hi, is this namespace prop required?

https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages#template-object

Here it says if is opcional on local api, I can't find a good doc for cloud api

https://developers.facebook.com/docs/whatsapp/business-platform/changelog#on-premiseswa2412