### PR TITLE
Add metadata to webhook messages

### DIFF
--- a/__tests__/webhook_client.test.ts
+++ b/__tests__/webhook_client.test.ts
@@ -120,14 +120,16 @@ describe("Webhook Client tests", () => {
 		const body = webhookBody;
 		const fields = webhookBodyFields;
 		const contact = body.entry[0].changes[0].value.contacts[0];
+		const metadata = body.entry[0].changes[0].value.metadata;
+
 		webhookHandler(body, events);
 		expect(events.onMessageReceived).toHaveBeenCalledTimes(2);
 		expect(events.onError).toHaveBeenCalledTimes(2);
 		expect(events.onStatusReceived).toHaveBeenCalledTimes(2);
 		expect(events.onTextMessageReceived).toHaveBeenCalledTimes(1);
-		expect(events.onMessageReceived).toHaveBeenCalledWith(fields.message, contact);
-		expect(events.onTextMessageReceived).toHaveBeenCalledWith(fields.textMessage, contact);
+		expect(events.onMessageReceived).toHaveBeenCalledWith(fields.message, contact, metadata);
+		expect(events.onTextMessageReceived).toHaveBeenCalledWith(fields.textMessage, contact, metadata);
 		expect(events.onError).toHaveBeenCalledWith(fields.error);
-		expect(events.onStatusReceived).toHaveBeenCalledWith(fields.status);
+		expect(events.onStatusReceived).toHaveBeenCalledWith(fields.status, metadata);
 	});
 });

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -1,6 +1,6 @@
 import { WABAErrorCodes } from "./error";
-import { LiteralUnion } from "./utils";
 import { MessageType, ReactionMessage } from "./messages";
+import { LiteralUnion } from "./utils";
 
 /**
  * The information for the customer who sent a message to the business
@@ -324,13 +324,15 @@ export type WebhookStatus = {
 	timestamp: number;
 };
 
+export type WebhookMetadata = {
+	display_phone_number: string;
+	phone_number_id: string;
+}
+
 export type WebhookChange = {
 	value: {
 		messaging_product: "whatsapp";
-		metadata: {
-			display_phone_number: string;
-			phone_number_id: string;
-		};
+		metadata: WebhookMetadata,
 		errors: WebhookError[];
 		contacts: WebhookContact[];
 		messages?: WebhookMessage[];
@@ -362,19 +364,20 @@ export type WebhookEvents = {
 	/**
 	 * This event gets fired on any webhooks messages, you'll have to differentiate between the message type
 	 */
-	onMessageReceived?: (payload: WebhookMessage, contact: WebhookContact) => void;
+	onMessageReceived?: (payload: WebhookMessage, contact: WebhookContact, metadata?: WebhookMetadata) => void;
 	/**
 	 * Gets fired when the received message is type of text
 	 */
 	onTextMessageReceived?: (
 		textMessage: Pick<WebhookMessage, "type" | "timestamp" | "text" | "from" | "id">,
-		contact: WebhookContact
+		contact: WebhookContact,
+		metadata?: WebhookMetadata
 	) => void;
 	/**
 	 * Gets triggered when a message is sent or delivered to a customer
 	 * or the customer reads the delivered message sent by a business that is subscribed to the Webhooks.
 	 */
-	onStatusReceived?: (payload: WebhookStatus) => void;
+	onStatusReceived?: (payload: WebhookStatus, metadata?: WebhookMetadata) => void;
 	/**
 	 * Gets fired whenever there is an err
 	 */

--- a/src/webhooks/helpers.ts
+++ b/src/webhooks/helpers.ts
@@ -18,7 +18,7 @@ export const webhookHandler = (
 				//The contact is always the 0 and it is only received when there the messages field is present
 				const contact = change?.value?.contacts[0];
 				//Call message event
-				onMessageReceived && onMessageReceived(message, contact);
+				onMessageReceived && onMessageReceived(message, contact, change?.value?.metadata);
 				//If the message is type of text, then call the respective event
 				if (message.type === "text" && message.text)
 					onTextMessageReceived &&
@@ -30,12 +30,13 @@ export const webhookHandler = (
 								from: message.from,
 								timestamp: message.timestamp,
 							},
-							contact
+							contact,
+							change?.value?.metadata,
 						);
 			});
 			//Call status event
 			change?.value?.statuses?.forEach((status) => {
-				onStatusReceived && onStatusReceived(status);
+				onStatusReceived && onStatusReceived(status, change?.value?.metadata);
 			});
 			//Call error event
 			change?.value?.errors?.forEach((err) => onError && onError(err));


### PR DESCRIPTION
I think it's useful to identify the `phone_number_id` besides the `message_id` for bookkeeping purposes. This way I can more easily follow a thread in our logic.

