### PR TITLE
Add "failed" to the enum for message status

### DIFF
--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -317,7 +317,7 @@ export type WebhookStatus = {
 	 * The WhatsApp ID for the customer that the business, that is subscribed to the webhooks, sent to the customer
 	 */
 	recipient_id: string;
-	status: "delivered" | "read" | "sent";
+	status: "delivered" | "failed" | "read" | "sent";
 	/**
 	 * Date for the status message in unix
 	 */


### PR DESCRIPTION
WAB messages can fail to send, in which case a webhook is received with `status: "failed"` but this value in not included in the types, so I've added it.