### PR TITLE
Fix `id` type of WebhookMessage from number to string

### DIFF
--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -114,7 +114,7 @@ export type WebhookMessage = {
 	/**
 	 * The ID for the message that was received by the business. You could use messages endpoint to mark it as read.
 	 */
-	id: number;
+	id: string;
 	/**
 	 * A webhook is triggered when a customer's phone number or profile information has been updated.
 	 */


### PR DESCRIPTION
Hello there, and thank you for this project and maintaining it. 

I noticed there is a mismatch between WhatsApp documentation on the webhook `message.id` property (which is the WAMI string), if you can compare with the reference doc: https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components#messages-object

![image](https://github.com/MarcosNicolau/whatsapp-business-sdk/assets/1182185/bb3e6ac1-15c8-4d9b-bf29-66bb249ceb72)

As I'm primarily using this library for the type declarations, I thought i would push this upstream, which would benefit the community.