### PR TITLE
Updated Webhook Types: Made 'filename' optional and corrected 'sha256' field. Changed 'timestamp' to number|string

### DIFF
--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -32,8 +32,8 @@ export type WebhookMedia = {
 	/**
 	 * Name for the file on the sender's device
 	 */
-	filename: string;
-	ha256: string;
+	filename?: string;
+	sha256: string;
 	mime_type: string;
 	/**
 	 * ID for the file
@@ -52,7 +52,7 @@ export type WebhookMessage = {
 	/**
 	 * The time when the customer sent the message to the business in unix format
 	 */
-	timestamp: number;
+	timestamp: number | string;
 	/**
 	 * When the messages type is set to audio, including voice messages, this object is included in the messages object:
 	 */
@@ -351,7 +351,7 @@ export type WebhookChange = {
 	value: {
 		messaging_product: "whatsapp";
 		metadata: WebhookMetadata;
-		errors: WebhookError[];
+		errors?: WebhookError[];
 		contacts: WebhookContact[];
 		messages?: WebhookMessage[];
 		statuses?: WebhookStatus[];

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -52,7 +52,7 @@ export type WebhookMessage = {
 	/**
 	 * The time when the customer sent the message to the business in unix format
 	 */
-	timestamp: number | string;
+	timestamp: string;
 	/**
 	 * When the messages type is set to audio, including voice messages, this object is included in the messages object:
 	 */
@@ -138,28 +138,28 @@ export type WebhookMessage = {
 	 */
 	interactive?: {
 		type: string;
-	    /**
-	     * Sent when a customer clicks a button
-	     */
-	    button_reply?: {
-	      /**
-	       *  Unique ID of a button
-	       */
-	      id: string;
-	      title: string;
-	    };
-	    /**
-	     *  Sent when a customer selects an item from a list
-	     */
-	    list_reply?: {
-	      /**
-	       * Unique ID of the selected list item
-	       */
-	      id: string;
-	      title: string;
-	      description: string;
-	    };
-	  };
+		/**
+		 * Sent when a customer clicks a button
+		 */
+		button_reply?: {
+			/**
+			 *  Unique ID of a button
+			 */
+			id: string;
+			title: string;
+		};
+		/**
+		 *  Sent when a customer selects an item from a list
+		 */
+		list_reply?: {
+			/**
+			 * Unique ID of the selected list item
+			 */
+			id: string;
+			title: string;
+			description: string;
+		};
+	};
 	/**
 	 * Included in the messages object when a customer has placed an order. Order objects have the following properties:
 	 */
@@ -339,7 +339,7 @@ export type WebhookStatus = {
 	/**
 	 * Date for the status message in unix
 	 */
-	timestamp: number;
+	timestamp: string;
 };
 
 export type WebhookMetadata = {


### PR DESCRIPTION
I received the object from the first webhook printscreen

 The DTO reported issues with the `filename`, `sha256` nomenclature, `timestamp` typing, and `value.errors` not informed in webhook

This PR contains:

- Turn `filename` as optional.
- Fix `ha256` to `sha256`.
- Allow the `timestamp` to accept string (and number)
- Turn `value.errors` as optional

**Problem:**
![image](https://github.com/MarcosNicolau/whatsapp-business-sdk/assets/8322467/40c43a71-6570-4528-b35a-153b506c2cee)

**Resolved:**
![image](https://github.com/MarcosNicolau/whatsapp-business-sdk/assets/8322467/5360f8f1-a30a-440e-bd09-81fc8e21d792)
