### PR TITLE
fix(WebhooksTypes): incorrect types

### DIFF
--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -45,8 +45,9 @@ type SharedMessageTypes = Exclude<MessageType, "template">;
 
 /**
  * For more information about this object, go here https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components#messages-object
- * Also take a look at the following examples docs, the above docs might not be up to date. 
- * https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/payload-examples#received-messages
+ * 
+ * Please also take a look at the examples for this object, because the docs for this object are not always up to date. 
+ * You can find the examples for this object here https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/payload-examples#received-messages
  */
 export type WebhookMessage = {
 	/**

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -45,12 +45,14 @@ type SharedMessageTypes = Exclude<MessageType, "template">;
 
 /**
  * For more information about this object, go here https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components#messages-object
+ * Also take a look at the following examples docs, the above docs might not be up to date. 
+ * https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/payload-examples#received-messages
  */
 export type WebhookMessage = {
 	/**
 	 * The type of message that has been received by the business that has subscribed to Webhooks.
 	 */
-	type: SharedMessageTypes | "system" | "unknown" | "button" | "order";
+	type: SharedMessageTypes | "system" | "unknown" | "request_welcome" | "button" | "order";
 	/**
 	 * The time when the customer sent the message to the business in unix format
 	 */

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -41,6 +41,8 @@ export type WebhookMedia = {
 	id: string;
 };
 
+type SharedMessageTypes = Exclude<MessageType, "contacts" | "location" | "template" | "reaction">;
+
 /**
  * For more information about this object, go here https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components#messages-object
  */
@@ -48,7 +50,7 @@ export type WebhookMessage = {
 	/**
 	 * The type of message that has been received by the business that has subscribed to Webhooks.
 	 */
-	type: MessageType | "system" | "unknown" | "request_welcome";
+	type: SharedMessageTypes | "system" | "unknown" | "button" | "order";
 	/**
 	 * The time when the customer sent the message to the business in unix format
 	 */

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -41,7 +41,7 @@ export type WebhookMedia = {
 	id: string;
 };
 
-type SharedMessageTypes = Exclude<MessageType, "contacts" | "location" | "template" | "reaction">;
+type SharedMessageTypes = Exclude<MessageType, "template">;
 
 /**
  * For more information about this object, go here https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components#messages-object


### PR DESCRIPTION
Not all types for outbound messages exist for inbound webhook messages.

Also "order" and "button" types only exist for the webhook messages and "request_welcome" does not exist in the cloud-api docs.