### PR TITLE
Fix: Current ruleset "Review needed" requires a pull request before merging 

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -49,7 +49,7 @@ jobs:
       - name: "Run build"
         run: yarn run build
       # Semantic release is configured to create a tag and publish the package to npm
-      - name: Semantic Release
+      - name: "Version and Npm publish"
         uses: cycjimmy/semantic-release-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -49,5 +49,8 @@ jobs:
       - name: "Run build"
         run: yarn run build
       # Semantic release is configured to create a tag and publish the package to npm
-      - name: "Version and Npm publish"
-        run: npx semantic-release
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
@MarcosNicolau 
Current GH action for release 'semantic-release'  is trying to push changes (version updates and tags) directly to the main branch as can be [seen here](https://github.com/MarcosNicolau/whatsapp-business-sdk/actions/runs/10368075600/job/28729290819), which is nonetheless being blocked by the current [repository rules](https://github.com/MarcosNicolau/whatsapp-business-sdk/rules/1323959).

We have three possible workarounds:
1. Modify repository rules.
2. Use a different branch for releases.
3. Use semantic-release's [GitHub Action](https://github.com/cycjimmy/semantic-release-action)
This GitHub Action for semantic-release that might handle these permissions better (i never used it though, so we have to test it). Why this PR does.

Feel free to take the best approach in your opinion.