### PR TITLE
fix(Webhooks): Types for InteractiveWebhookMessageNfmReply

### DIFF
--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -48,12 +48,23 @@ export type WebhookMedia = {
  */
 export type InteractiveWebhookMessageNfmReplyName =  "address_message" | "flow" | string;
 
-export type InteractiveWebhookMessageNfmReply<Name extends InteractiveWebhookMessageNfmReplyName = string> = {
-    name?: Name;
-    response_json: string;
-} & Name extends "flow"
-    ? { body: "Sent" }
-    : { body?: string };
+export type InteractiveWebhookMessageNfmReply<Name extends InteractiveWebhookMessageNfmReplyName = string> =
+	(
+		Name extends "flow"
+    		? { body: "Sent" }
+    		: { body?: string }
+	)
+	&
+	(
+		Name extends "flow" | "address_message"
+			? { name: Name }
+			: { name?: string }
+	)
+	&
+	{
+		response_json: string;
+	}
+
 
 export interface InteractiveWebhookMessageListReply {
     /**

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -58,13 +58,12 @@ export type InteractiveWebhookMessageNfmReply<Name extends InteractiveWebhookMes
 	(
 		Name extends "flow" | "address_message"
 			? { name: Name }
-			: { name?: string }
+			: { name?: Name }
 	)
 	&
 	{
 		response_json: string;
 	}
-
 
 export interface InteractiveWebhookMessageListReply {
     /**


### PR DESCRIPTION
Using `InteractiveWebhookMessageNfmReply` is broken because the type unions are not being combined correctly.


```typescript

// Works now:

const interactiveWebhookMessageNfmFlowReply: InteractiveWebhookMessageNfmReply<"flow"> = {
	body: "Sent",
	name: "flow",
	response_json: "..."
}

const interactiveWebhookMessageNfmAddressReply: InteractiveWebhookMessageNfmReply<"address_message"> = {
	// optional in this case
	body: "...",
	name: "address_message",
	response_json: "..."
}


const interactiveWebhookMessageNfmUnknownReply: InteractiveWebhookMessageNfmReply<"apparently-there-are-other-types"> = {
	// optional in this case
	body: "...",
	// optional in this case
	name: "apparently-there-are-other-types",
	response_json: "..."
}

```