### PR TITLE
fix: contacts message to be an array

### DIFF
--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -77,7 +77,7 @@ export type Message = {
 	/**
 	 * Required when type=contacts
 	 */
-	contacts?: ContactMessage;
+	contacts?: ContactMessage[];
 	/**
 	 * Required when type=document
 	 */


### PR DESCRIPTION
According to Meta Reference [documentation](https://developers.facebook.com/docs/whatsapp/api/messages/contacts-location-messages/#paso-1--realizar-una-solicitud-post-a--messages)  contacts property should be an array