### PR TITLE
Add `apiVersion` to WABAClientArgs

### DIFF
--- a/src/WABA_client.ts
+++ b/src/WABA_client.ts
@@ -28,6 +28,7 @@ import { createRestClient } from "./utils/restClient";
 
 interface WABAClientArgs {
 	apiToken: string;
+	apiVersion?: string;
 	phoneId: string;
 	accountId: string;
 }
@@ -42,12 +43,12 @@ export class WABAClient {
 	phoneId: string;
 	accountId: string;
 
-	constructor({ apiToken, phoneId, accountId }: WABAClientArgs) {
+	constructor({ apiToken, apiVersion = "v19.0", phoneId, accountId }: WABAClientArgs) {
 		this.phoneId = phoneId;
 		this.accountId = accountId;
 		this.restClient = createRestClient({
 			apiToken,
-			baseURL: "https://graph.facebook.com/v19.0",
+			baseURL: `https://graph.facebook.com/${apiVersion}`,
 			errorHandler: (error) => WABAErrorHandler(error?.response?.data || error),
 		});
 	}

--- a/src/WABA_client.ts
+++ b/src/WABA_client.ts
@@ -43,12 +43,12 @@ export class WABAClient {
 	phoneId: string;
 	accountId: string;
 
-	constructor({ apiToken, apiVersion = "v19.0", phoneId, accountId }: WABAClientArgs) {
+	constructor({ apiToken, apiVersion, phoneId, accountId }: WABAClientArgs) {
 		this.phoneId = phoneId;
 		this.accountId = accountId;
 		this.restClient = createRestClient({
 			apiToken,
-			baseURL: `https://graph.facebook.com/${apiVersion}`,
+			baseURL: `https://graph.facebook.com/${apiVersion || "v19.0"}`,
 			errorHandler: (error) => WABAErrorHandler(error?.response?.data || error),
 		});
 	}

--- a/src/WABA_client.ts
+++ b/src/WABA_client.ts
@@ -48,6 +48,7 @@ export class WABAClient {
 		this.accountId = accountId;
 		this.restClient = createRestClient({
 			apiToken,
+			// If no apiVersion is provided, defaults to v19.0
 			baseURL: `https://graph.facebook.com/${apiVersion || "v19.0"}`,
 			errorHandler: (error) => WABAErrorHandler(error?.response?.data || error),
 		});


### PR DESCRIPTION
It removes the hardcoded value “v19.0” from the `baseUrl` of the REST client, allowing the developer to use an older/newer API version if needed.

Although, I left the said API version as the default value so as not to impact existing deployments.